### PR TITLE
Updated to not write files to tmp directory and just keep in memory

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,7 @@ module.exports = function(opt, execFile_opt) {
     var dirName = uuid.v4();
     var src = files.map(function(file) {
       var relativePath = path.relative(file.cwd, file.path);
-      var fullpath = path.join(tmpdir, dirName, relativePath);
-      mkdirp.sync(path.dirname(fullpath));
-      fs.writeFileSync(fullpath, file.contents.toString());
-      return '--js="' + fullpath + '"';
+      return '--js="' + relativePath + '"';
     }).join('\n');
     return tempWrite.sync(src);
   };


### PR DESCRIPTION
By default, the plugin copies files to the tmp folder on system and fills up space. I don't think this is needed and can just keep in memory of gulp. 