### PR TITLE
Take relative path to file.base rather than file.cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function(opt, execFile_opt) {
   var getFlagFilePath = function(files) {
     var dirName = uuid.v4();
     var src = files.map(function(file) {
-      var relativePath = path.relative(file.cwd, file.path);
+      var relativePath = path.relative(file.base, file.path);
       var fullpath = path.join(tmpdir, dirName, relativePath);
       mkdirp.sync(path.dirname(fullpath));
       fs.writeFileSync(fullpath, file.contents.toString());


### PR DESCRIPTION
Fixes #21 

if your file.path is not under current dir, relative path will be something like `../../../dir/file.js` and once temp-write takes that, it will convert this into   `'/tmp/ ' + '../../../dir/file.js'` and that the dirname out of that, which is `/dir` where user is not allowed to write.