### PR TITLE
Verbose error reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,8 @@ module.exports = function(opt, execFile_opt) {
     var executable = opt.compilerPath ? 'java' : 'closure-compiler';
     var jar = execFile(executable, args, { maxBuffer: opt.maxBuffer*1024 }, function(error, stdout, stderr) {
       if (error || (stderr && !opt.continueWithWarnings)) {
-        this.emit('error', new gutil.PluginError(PLUGIN_NAME, error || stderr));
+        var message = 'executing "' + executable + '" failed: ' + (error || stderr);
+        this.emit('error', new gutil.PluginError(PLUGIN_NAME, message));
         process.exit(1);
         return;
       }


### PR DESCRIPTION
This commit helps to identify the issue on spawn fail.

before: `"spawn ENOENT"`

![screen shot 2015-03-01 at 15 29 53](https://cloud.githubusercontent.com/assets/1100170/6431237/655ea97c-c029-11e4-9bad-463045f52a36.png)

after: `"executing 'java' failed: spawn ENOENT"`
![screen shot 2015-03-01 at 15 37 27](https://cloud.githubusercontent.com/assets/1100170/6431239/67ca04c2-c029-11e4-9eac-5b0a3d1ce121.png)
