### PR TITLE
Deactivates and set tiered compilation to an option, see issue #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ Type: `Object`
 
 Closure compiler [flags](https://github.com/steida/gulp-closure-compiler/blob/master/flags.txt).
 
+##### tieredCompilation
+
+Type: `Boolean`  
+
+Tiered compilation enhances the speed of compilation. It's supported everywhere since Java 1.7+, but requires the installation of a JDK.
+
 ##### maxBuffer
 
 Type: `Number` 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = function(opt, execFile_opt) {
       args = [
         '-jar',
         // For faster compilation. It's supported everywhere from Java 1.7+.
-        '-XX:+TieredCompilation',
+        opt.tieredCompilation ? '-XX:+TieredCompilation' : '-XX:-TieredCompilation',
         opt.compilerPath,
         // To prevent maximum length of command line string exceeded error.
         '--flagfile="' + getFlagFilePath(files) + '"'

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "minify"
   ],
   "dependencies": {
-    "glob": "^4.3.2",
-    "graceful-fs": "^3.0.5",
+    "glob": "^5.0.14",
+    "graceful-fs": "^4.1.2",
     "gulp-util": "^3.0.0",
     "mkdirp": "^0.5.0",
     "temp-write": "^1.0.0",
@@ -41,6 +41,6 @@
     "event-stream": "^3.1.0",
     "gulp": "^3.5.6",
     "mocha": "*",
-    "vinyl": "^0.4.3"
+    "vinyl": "^0.5.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ it('should minify JS', function (done) {
 	var execFile = function(cmd, args, cb) {
     assert.equal(cmd, 'java');
     assert.equal(args[0], '-jar');
-    assert.equal(args[1], '-XX:+TieredCompilation');
+    assert.equal(args[1], '-XX:-TieredCompilation');
     assert.equal(args[2], 'compiler.jar');
     assert.ok(/^--flagfile=/.test(args[3]));
     assert.ok(/^--js_output_file=/.test(args[4]));
@@ -40,7 +40,7 @@ it('source maps are being generated', function (done) {
   var execFile = function(cmd, args, options, cb) {
     assert.equal(cmd, 'java');
     assert.equal(args[0], '-jar');
-    assert.equal(args[1], '-XX:+TieredCompilation');
+    assert.equal(args[1], '-XX:-TieredCompilation');
     assert.equal(args[2], 'compiler.jar');
     assert.ok(/^--flagfile=/.test(args[3]));
     assert.ok(/^--create_source_map=/.test(args[4]));


### PR DESCRIPTION
As asked in issue #38, tiered compilation is deactivated by default and moved as an option. I also upgraded dependencies.