### PR TITLE
Use google-closure-compiler 20151015.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "minify"
   ],
   "dependencies": {
-    "google-closure-compiler": "^20151015.0.0",
+    "google-closure-compiler": "^20151015.7.0",
     "glob": "^5.0.14",
     "graceful-fs": "^4.1.2",
     "gulp-util": "^3.0.0",


### PR DESCRIPTION
`npm i` installs it, even though npmjs.com didn't update yet.